### PR TITLE
stopper: add FromDelegate

### DIFF
--- a/stopper/stopper.go
+++ b/stopper/stopper.go
@@ -16,6 +16,12 @@
 
 // Package stopper contains a utility class for gracefully terminating
 // long-running processes.
+//
+// Values attached to a context above a stopper (for example, an OpenTelemetry
+// span installed by HTTP middleware or a runtime/trace task) are not visible
+// through [From], which only walks toward the root of the context chain. Use
+// [FromDelegate] at boundaries where the incoming context may carry such
+// values and you want a Context that can see them.
 package stopper
 
 import (
@@ -32,6 +38,7 @@ type contextKey struct{}
 var background = &Context{
 	delegate: context.Background(),
 	stopping: make(chan struct{}),
+	mu:       &lifecycle{},
 }
 
 // ErrStopped will be returned from [context.Cause] when the Context has
@@ -58,13 +65,20 @@ type Context struct {
 	stopping chan struct{}
 	parent   *Context
 
-	mu struct {
-		sync.RWMutex
-		count    int
-		deferred []func()
-		err      error
-		stopping bool
-	}
+	// mu is a pointer so that wrappers produced by FromDelegate can
+	// share the same lifecycle bookkeeping as the original.
+	mu *lifecycle
+}
+
+// lifecycle holds the mutex-protected bookkeeping shared by a Context and
+// any wrappers created via FromDelegate. It is referenced by pointer so
+// that the wrappers and the original observe and mutate the same state.
+type lifecycle struct {
+	sync.RWMutex
+	count    int
+	deferred []func()
+	err      error
+	stopping bool
 }
 
 var _ context.Context = (*Context)(nil)
@@ -79,6 +93,10 @@ func Background() *Context { return background }
 //
 // If the chain is not associated with a Context, the [Background]
 // instance will be returned.
+//
+// See [FromDelegate] when ctx is derived from a stopper and may carry
+// additional values (OTel spans, runtime/trace tasks) that the returned
+// Context would otherwise hide.
 func From(ctx context.Context) *Context {
 	if s, ok := ctx.(*Context); ok {
 		return s
@@ -87,6 +105,39 @@ func From(ctx context.Context) *Context {
 		return s.(*Context)
 	}
 	return Background()
+}
+
+// FromDelegate is like [From] but returns a Context whose Value,
+// Deadline, Done, and Err methods delegate to ctx, while Stop, Go, Defer,
+// Stopping, and Wait still act on the original stopper installed in ctx.
+// The common shape at HTTP boundaries is:
+//
+//	stop := stopper.FromDelegate(req.Context())
+//
+// Use this when a foreign library has added values above the stopper, for
+// example an OpenTelemetry span installed by middleware, a runtime/trace
+// task, or any context.WithValue layered on top, and downstream code
+// needs a stopper that can see them.
+//
+// When ctx does not have a stopper installed, FromDelegate returns
+// [Background] unchanged and the values in ctx are not preserved.
+//
+// Stacking FromDelegate calls is safe: nested wrappers share one
+// lifecycle with the original stopper rather than forming a chain.
+// Values added at any layer of the context chain remain visible because
+// Value lookup still walks through each delegate.
+func FromDelegate(ctx context.Context) *Context {
+	c := From(ctx)
+	if c == background {
+		return c
+	}
+	return &Context{
+		cancel:   c.cancel,
+		delegate: ctx,
+		stopping: c.stopping,
+		parent:   c.parent,
+		mu:       c.mu,
+	}
 }
 
 // IsStopping is a convenience method to determine if a stopper is
@@ -110,6 +161,7 @@ func WithContext(ctx context.Context) *Context {
 		delegate: ctx,
 		parent:   parent,
 		stopping: make(chan struct{}),
+		mu:       &lifecycle{},
 	}
 
 	// Propagate a parent stop or context cancellation into a Stop call

--- a/stopper/stopper_test.go
+++ b/stopper/stopper_test.go
@@ -280,3 +280,140 @@ func TestUnused(t *testing.T) {
 	a.ErrorIs(context.Cause(s), ErrStopped)
 	a.Nil(s.Wait())
 }
+
+func TestFromDelegateSeesDescendantValues(t *testing.T) {
+	a := assert.New(t)
+
+	type ctxKey struct{}
+	s := WithContext(context.Background())
+	withVal := context.WithValue(s, ctxKey{}, "v")
+
+	// Sanity check: the original stopper cannot see values attached
+	// above it in the chain.
+	a.Nil(s.Value(ctxKey{}))
+
+	// FromDelegate surfaces the value.
+	a.Equal("v", FromDelegate(withVal).Value(ctxKey{}))
+}
+
+func TestFromDelegatePreservesLifecycle(t *testing.T) {
+	a := assert.New(t)
+
+	type ctxKey struct{}
+
+	// Stop on the original cancels a goroutine started via the wrapper,
+	// and the wrapper's Done channel fires once the goroutine exits.
+	{
+		s := WithContext(context.Background())
+		delegated := FromDelegate(context.WithValue(s, ctxKey{}, "v"))
+
+		done := make(chan struct{})
+		a.True(delegated.Go(func(ctx *Context) error {
+			<-ctx.Stopping()
+			close(done)
+			return nil
+		}))
+
+		s.Stop(time.Second)
+		select {
+		case <-done:
+		// OK
+		case <-time.After(time.Second):
+			a.Fail("delegated goroutine did not exit after s.Stop")
+		}
+		select {
+		case <-delegated.Done():
+		// OK
+		case <-time.After(time.Second):
+			a.Fail("delegated.Done() did not fire after s.Stop")
+		}
+	}
+
+	// Stop on the wrapper cancels a goroutine started via the original,
+	// and the wrapper's Done channel fires once the goroutine exits.
+	{
+		s := WithContext(context.Background())
+		delegated := FromDelegate(context.WithValue(s, ctxKey{}, "v"))
+
+		done := make(chan struct{})
+		a.True(s.Go(func(ctx *Context) error {
+			<-ctx.Stopping()
+			close(done)
+			return nil
+		}))
+
+		delegated.Stop(time.Second)
+		select {
+		case <-done:
+		// OK
+		case <-time.After(time.Second):
+			a.Fail("original goroutine did not exit after delegated.Stop")
+		}
+		select {
+		case <-delegated.Done():
+		// OK
+		case <-time.After(time.Second):
+			a.Fail("delegated.Done() did not fire after delegated.Stop")
+		}
+	}
+}
+
+func TestFromDelegateDeadline(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+
+	// The stopper alone has no deadline.
+	_, ok := s.Deadline()
+	a.False(ok)
+
+	deadline := time.Now().Add(10 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(s, deadline)
+	defer cancel()
+
+	got, ok := FromDelegate(ctx).Deadline()
+	a.True(ok)
+	a.WithinDuration(deadline, got, time.Millisecond)
+}
+
+func TestFromDelegateNested(t *testing.T) {
+	a := assert.New(t)
+
+	type key1 struct{}
+	type key2 struct{}
+
+	s := WithContext(context.Background())
+
+	ctx1 := context.WithValue(s, key1{}, "v1")
+	w1 := FromDelegate(ctx1)
+
+	ctx2 := context.WithValue(w1, key2{}, "v2")
+	w2 := FromDelegate(ctx2)
+
+	// Values from both wrapping layers are visible through w2.
+	a.Equal("v1", w2.Value(key1{}))
+	a.Equal("v2", w2.Value(key2{}))
+
+	// Lifecycle is shared all the way to s: Stop on the outermost
+	// wrapper closes s.Stopping().
+	w2.Stop(0)
+	select {
+	case <-s.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("s.Stopping() did not close after w2.Stop")
+	}
+}
+
+func TestFromDelegateBackgroundReturnsBackground(t *testing.T) {
+	a := assert.New(t)
+
+	// When ctx has no stopper installed, FromDelegate returns Background
+	// and the values in ctx are not preserved.
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "v")
+
+	fd := FromDelegate(ctx)
+	a.Same(background, fd)
+	a.Nil(fd.Value(ctxKey{}))
+}


### PR DESCRIPTION
## Summary

- `Context.Value` walks down the context chain, so values attached above a stopper (OpenTelemetry spans installed by HTTP middleware, runtime/trace tasks, anything from `context.WithValue` layered on top) are invisible to `From` and to anything derived from it.
- Adds `FromDelegate(ctx)`: returns a Context whose `Value`, `Deadline`, `Done`, `Err` delegate to ctx while `Stop`, `Go`, `Defer`, `Stopping`, `Wait` still act on the original stopper installed in ctx. Intended for HTTP boundaries where the request context may carry tracing values added above the upstream stopper.
- Refactor: the embedded `mu` struct is extracted to a named `lifecycle` type and the field becomes a pointer so the original and any wrappers share the same bookkeeping. No public API changes; existing `c.mu.X` accesses are unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/field-eng-powertools/36)
<!-- Reviewable:end -->
